### PR TITLE
Discrete

### DIFF
--- a/xbo/convenience_test.go
+++ b/xbo/convenience_test.go
@@ -47,6 +47,21 @@ func TestConvenienceBackOffs(t *testing.T) {
 			ZeroDuration,
 			ErrStop,
 		},
+		{
+			NewLoop([]time.Duration{}, true),
+			ZeroDuration,
+			ErrStop,
+		},
+		{
+			NewLimit([]time.Duration{}, true),
+			ZeroDuration,
+			ErrStop,
+		},
+		{
+			NewEcho([]time.Duration{}, true),
+			ZeroDuration,
+			ErrStop,
+		},
 	}
 
 	// We want to test that each of the convenience BackOff types

--- a/xbo/sequence.go
+++ b/xbo/sequence.go
@@ -1,0 +1,106 @@
+// Copyright © 2017 Nelz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xbo
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// NewLoop allows the client to define a discrete list of durations that
+// will be continually looped over, without end. Resets do put the iteration
+// back to the first item.
+//
+// Misconfiguraiton (0-length slice) will create a Backoff that always
+// returns ErrStop (when not being reset).
+func NewLoop(durs []time.Duration, safe bool) BackOff {
+	return newSequence(durs, safe, true, false)
+}
+
+// NewLimit allows the client to define a discrete list of durations that
+// will be returned until the list runs out, at which time the BackOff will
+// just return ErrStop, until reset.
+//
+// Misconfiguraiton (0-length slice) will create a Backoff that always
+// returns ErrStop (when not being reset).
+func NewLimit(durs []time.Duration, safe bool) BackOff {
+	return newSequence(durs, safe, false, false)
+}
+
+// NewEcho allows the client to define a discrete list of durations that
+// will be returned until the list runs out, at which time the last duration
+// in the list will be continually returned, until a reset.
+//
+// Misconfiguraiton (0-length slice) will create a Backoff that always
+// returns ErrStop (when not being reset).
+func NewEcho(durs []time.Duration, safe bool) BackOff {
+	return newSequence(durs, safe, false, true)
+}
+
+func newSequence(durs []time.Duration, safe bool, loop bool, echo bool) BackOff {
+	// Since we are trying to protect some underlying resource, if the user
+	// specified an empty (nonsensical) slice, then default to stopping
+	// any retries
+	size := uint32(len(durs))
+	if size == 0 {
+		return NewStop()
+	}
+
+	count := uint32(0)
+	return BackOffFunc(func(reset bool) (time.Duration, error) {
+		// Reset is pretty easy
+		if reset {
+			if safe {
+				atomic.StoreUint32(&count, 0)
+			} else {
+				count = 0
+			}
+			return ZeroDuration, nil
+		}
+
+		// After calculating the current duration we will increase the count
+		// for the next time around
+		defer func() {
+			next := count + 1
+			if safe {
+				atomic.AddUint32(&count, 1)
+			} else {
+				count = next
+			}
+		}()
+
+		offset := count
+		if loop {
+			offset = count % size
+		}
+
+		// Short-circuit if we're at the max size
+		if offset >= size {
+			if echo {
+				// Just echo the last entry
+				return durs[size-1], nil
+			}
+			return ZeroDuration, ErrStop
+		}
+
+		return durs[offset], nil
+	})
+}

--- a/xbo/sequence_test.go
+++ b/xbo/sequence_test.go
@@ -1,0 +1,124 @@
+// Copyright © 2017 Nelz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xbo
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSequenceBackOffs(t *testing.T) {
+	// Testing each of the convenience BackOff types
+	testCases := []struct {
+		iterations int
+		bos        []BackOff
+	}{
+		{
+			5,
+			[]BackOff{
+				NewConstant(time.Second),
+				NewLoop([]time.Duration{time.Second}, true),
+				NewLoop([]time.Duration{time.Second}, false),
+				NewEcho([]time.Duration{time.Second}, true),
+				NewEcho([]time.Duration{time.Second}, false),
+				NewLimit([]time.Duration{
+					time.Second, time.Second, time.Second, time.Second, time.Second,
+				}, true),
+				NewLimit([]time.Duration{
+					time.Second, time.Second, time.Second, time.Second, time.Second,
+				}, false),
+			},
+		},
+		{
+			6,
+			[]BackOff{
+				NewLoop([]time.Duration{
+					time.Millisecond, time.Second, time.Minute,
+				}, true),
+				NewLoop([]time.Duration{
+					time.Millisecond, time.Second, time.Minute,
+				}, false),
+				NewEcho([]time.Duration{
+					time.Millisecond, time.Second, time.Minute,
+					time.Millisecond, time.Second, time.Minute,
+				}, true),
+				NewEcho([]time.Duration{
+					time.Millisecond, time.Second, time.Minute,
+					time.Millisecond, time.Second, time.Minute,
+				}, false),
+				NewLimit([]time.Duration{
+					time.Millisecond, time.Second, time.Minute,
+					time.Millisecond, time.Second, time.Minute,
+				}, true),
+				NewLimit([]time.Duration{
+					time.Millisecond, time.Second, time.Minute,
+					time.Millisecond, time.Second, time.Minute,
+				}, false),
+			},
+		},
+		{
+			10,
+			[]BackOff{
+				MaxAttempts(NewConstant(time.Minute), 4, true),
+				NewLimit([]time.Duration{
+					time.Minute, time.Minute, time.Minute, time.Minute,
+				}, true),
+				NewLimit([]time.Duration{
+					time.Minute, time.Minute, time.Minute, time.Minute,
+				}, false),
+			},
+		},
+	}
+
+	// Each testCase should hold a set of BackOffs that will return
+	// equivalent results, for the duration of specified iterations.
+	for _, tc := range testCases {
+		for ct := 0; ct < tc.iterations; ct++ {
+			var xDur time.Duration
+			var xErr error
+			for ix, bo := range tc.bos {
+				// We'll use the first BackOff as the standard for this iteration
+				if ix == 0 {
+					xDur, xErr = bo.Next(false)
+					continue
+				}
+				dur, err := bo.Next(false)
+				if dur != xDur {
+					t.Errorf("expected %s: %s", xDur, dur)
+				}
+				if err != xErr {
+					t.Errorf("expected %v: %v", xErr, err)
+				}
+			}
+		}
+
+		for _, bo := range tc.bos {
+			// Also test that reset gets the expected standard results
+			dur, err := bo.Next(true)
+			if dur != ZeroDuration {
+				t.Errorf("expected %s: %s", ZeroDuration, dur)
+			}
+			if err != nil {
+				t.Errorf("unexpected: %v", err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Give uses the ability to define a concrete list of discrete (in the mathematical sense) values. They can define a loop, a list after which `ErrStop` is returned, or a list after which the last value is just continually echoed.